### PR TITLE
Update actions/setup-go to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go }}
     - run: go version


### PR DESCRIPTION
Update actions/setup-go to v6.

Versions of actions/setup-go prior to v4 no longer work due to changes in the Go download URLs (see https://github.com/actions/setup-go/issues/688). While updating repos affected by that, figured may as well update all repos using any version earlier than the latest.