### PR TITLE
Fix memory leak from goRawXdr not being freed

### DIFF
--- a/xdrjson/conversion.go
+++ b/xdrjson/conversion.go
@@ -31,19 +31,17 @@ import (
 // Returns the JSON message if decoding successful, otherwise an error.
 func Decode(xdrTypeName XdrType, xdrBinary []byte) (json.RawMessage, error) {
 	var jsonStr, errStr string
-	// scope just added to show matching alloc/frees
-	{
-		goRawXdr := CXDR(xdrBinary)
-		b := C.CString(string(xdrTypeName))
+	goRawXdr := CXDR(xdrBinary)
+	defer FreeGoXDR(goRawXdr)
 
-		result := C.xdr_to_json(b, goRawXdr)
-		C.free(unsafe.Pointer(b))
+	b := C.CString(string(xdrTypeName))
+	defer C.free(unsafe.Pointer(b))
 
-		jsonStr = C.GoString(result.json)
-		errStr = C.GoString(result.error)
+	result := C.xdr_to_json(b, goRawXdr)
+	defer C.free_conversion_result(result)
 
-		C.free_conversion_result(result)
-	}
+	jsonStr = C.GoString(result.json)
+	errStr = C.GoString(result.error)
 
 	if errStr != "" {
 		return json.RawMessage(jsonStr), errors.New(errStr)
@@ -58,4 +56,8 @@ func CXDR(xdr []byte) C.xdr_t {
 		xdr: (*C.uchar)(C.CBytes(xdr)),
 		len: C.size_t(len(xdr)),
 	}
+}
+
+func FreeGoXDR(xdr C.xdr_t) {
+	C.free(unsafe.Pointer(xdr.xdr))
 }


### PR DESCRIPTION
### What

Fixes a memory leak resulting from `goRawXdr` not being freed in `xdr2json/conversion.go::Decode()`. Removed unnecessary scoping to match patterns in `stellar/stellar-rpc/internal/xdr2json/conversion.go` and reduce ambiguity.

### Why

This caused a leak of size `len(goRawXdr)`, which presents a vulnerability.

### Known limitations

N/A