### PR TITLE
Fix package build in cross-compile environments

### DIFF
--- a/xdrjson/conversion.go
+++ b/xdrjson/conversion.go
@@ -1,3 +1,5 @@
+//go:build cgo && ((windows && amd64) || (darwin && amd64) || (darwin && arm64) || (linux && amd64) || (linux && arm64))
+
 //nolint:lll
 package xdrjson
 

--- a/xdrjson/conversion_unsupported.go
+++ b/xdrjson/conversion_unsupported.go
@@ -1,0 +1,18 @@
+//go:build !(cgo && ((windows && amd64) || (darwin && amd64) || (darwin && arm64) || (linux && amd64) || (linux && arm64)))
+
+package xdrjson
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// Decode is the unsupported-platform stub. The real cgo-backed implementation
+// lives in conversion.go and is only compiled when cgo is enabled on a
+// supported platform. On all other configurations this stub is compiled
+// instead so that the package still builds, and Decode returns an error.
+func Decode(xdrTypeName XdrType, xdrBinary []byte) (json.RawMessage, error) {
+	return nil, errors.New("xdrjson.Decode requires cgo on a supported platform " +
+		"(windows/amd64, darwin/amd64, darwin/arm64, linux/amd64, or linux/arm64)")
+}


### PR DESCRIPTION
### What

Constrain the cgo-backed implementation to builds where cgo is enabled on a platform that ships a prebuilt static library, and add a fallback implementation of `Decode` for every other build configuration that returns an error describing the package's requirements.

### Why

The package links a Rust library through cgo, and `conversion.go` — the only file that defines `Decode` — implicitly compiles only when cgo is enabled. When the package is cross-compiled with cgo disabled, which is the default whenever a C cross-toolchain isn't configured, that file drops out of the build and every consumer fails, originally with "build constraints exclude all Go files" and now with "undefined: xdrjson.Decode", as reported when building horizon for darwin/amd64 in issue #12. Keeping a non-cgo `Decode` in the build means the package and its dependents always compile, while code that actually needs decoding on an unsupported target receives a clear runtime error instead of a build break.

Close #12


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5Wz2N8ezNoJpbozkmLSB2)_