### PR TITLE
Make prebuilt lib builds reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     # The stellar/rust-cache action is not used to ensure that the libs are
-    # reproducible with no cache.
-    - run: rustup update
-    - run: cargo version
+    # reproducible with no cache. The build runs entirely inside the
+    # digest-pinned image in `make build-libs`, so the runner's host toolchain
+    # does not affect the produced libs.
     - run: make build-libs
     - run: git add -N . && git diff HEAD --exit-code
     - uses: actions/upload-artifact@v4
@@ -82,7 +82,7 @@ jobs:
         - os: ubuntu-latest    # amd64
         - os: ubuntu-22.04-arm # arm64
         - os: macos-latest     # arm64
-        - os: macos-13         # amd64
+        - os: macos-15-intel   # amd64
         - os: windows-latest   # amd64
     runs-on: ${{ matrix.sys.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,16 @@ TARGETS = \
 LIBS_DIR = xdrjson/libs
 BUILD_DIR = target
 PROFILE = release-with-panic-unwind
+# Build image, pinned by digest (not just tag) so its OS layer can't drift, so
+# that the binaries are reproducible.
+IMAGE = rust:1.84.1-bullseye@sha256:1e3f7a9fd1f278cc4be02a830745f40fe4b22f0114b2464a452c50273cc1020d
 
 # Build all libraries
-build-libs: Cargo.lock
-	docker run --rm -v $$PWD:/wd -w /wd --platform=linux/amd64 rust:1.84.1-bullseye /bin/bash -c '\
+build-libs:
+	docker run --rm -v $$PWD:/wd -w /wd --platform=linux/amd64 $(IMAGE) /bin/bash -c '\
 		rustc -vV > $(LIBS_DIR)/rust-version; \
 		for target in $(TARGETS); do \
-			cargo build --profile $(PROFILE) --target $$target --package xdrjson; \
+			cargo build --locked --profile $(PROFILE) --target $$target --package xdrjson; \
 			mkdir -p $(LIBS_DIR)/$$target; \
 			cp $(BUILD_DIR)/$$target/$(PROFILE)/*.a $(LIBS_DIR)/$$target/; \
 		done; \


### PR DESCRIPTION
### What

Make `make build-libs` reproduce the committed prebuilt static libraries by fixing the build inputs that were drifting: pin the cross-compilation Docker image by digest, build with `cargo build --locked`, and stop the lib build from regenerating `Cargo.lock` on the host. The CI `check-libs-reproducible` job is also simplified to stop relying on the runner's host Rust toolchain, and its amd64 macOS matrix entry moves from the (currently starved) `macos-13` runner to `macos-15-intel`. The committed `.a` files are unchanged — they remain byte-identical to what is on `main`.

### Why

The `check-libs-reproducible` job rebuilds the committed `.a` files and fails if they differ, but its inputs were not actually fixed. The build image was referenced by the mutable `rust:1.84.1-bullseye` tag, which is rebuilt as its base OS layer is updated, and `build-libs` depended on a `Cargo.lock` rule whose recipe runs `cargo update` on the host outside the container — either of which could change the output between two runs of the same commit, which is why the check could pass in a PR and later fail on `main`. Pinning the image by digest fixes the OS layer, and `cargo build --locked` consumes the committed `Cargo.lock` as-is and fails loudly rather than silently updating it.

`rust-toolchain.toml` is intentionally left unchanged at `channel = "stable"`: the produced `.a` content embeds the rustup toolchain directory name (e.g. `stable-...`) in std debuginfo paths and LLVM codegen-unit hashes, so changing the channel to a numbered version would change the committed bytes even though the compiler is identical. Keeping `stable` reproduces the committed libraries byte-for-byte. The known trade-off is that the compiler still floats as `stable` advances, so the libraries need to be regenerated when a new stable release lands.

Close #11