### PR TITLE
Fix macOS Intel CI runs that are broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         - os: ubuntu-latest    # amd64
         - os: ubuntu-22.04-arm # arm64
         - os: macos-latest     # arm64
-        - os: macos-13         # amd64
+        - os: macos-15-intel   # amd64
         - os: windows-latest   # amd64
     runs-on: ${{ matrix.sys.os }}
     steps:


### PR DESCRIPTION
### What

Switch the amd64 macOS entry in the build-and-test matrix from the `macos-13` runner to the `macos-15-intel` runner.

### Why

GitHub retired the `macos-13` hosted runner image, so the Intel/amd64 leg of the CI matrix is stalling on recent runs. `macos-15-intel` is the latest Intel-architecture macOS runner.

---
_Generated by [Claude Code](https://claude.ai/code/session_011caVcmwV8tgMqPD46Dn4re)_